### PR TITLE
Fix velocity TTL, dispute path, and multi-worker shard ownership.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ That only means the event is on the stream. The decision comes from `GET /paymen
 
 Replicas stay consistent because scoring depends on shared stores, not process-local RAM.
 
+Workers partition Kinesis shards by `worker_name` index and `worker_replicas` so multiple EC2 instances do not double-score the same records. Keep Ansible `worker_replicas` equal to the number of hosts in the workers group (Terraform `worker_count`).
+
 ---
 
 ## Rules (v1)
@@ -74,6 +76,14 @@ Replicas stay consistent because scoring depends on shared stores, not process-l
 | `VELOCITY_CARD` | N txns / card / window | Redis |
 | `VELOCITY_IP` | N txns / IP / window | Redis |
 | `HISTORY_DISPUTE` | prior dispute on card | DynamoDB |
+
+Mark a scored txn as disputed (local ingest) so later payments on that card trip `HISTORY_DISPUTE`:
+
+```bash
+curl -s -X POST http://localhost:8080/v1/payments/TXN_ID/dispute \
+  -H 'Content-Type: application/json' \
+  -d '{"card_id":"card-1"}'
+```
 
 Score stack: ≥80 `DECLINE`, ≥40 `REVIEW`, else `ALLOW`. Rules are pure over `(payment, snapshot)` so any worker with the same snapshot scores the same way.
 
@@ -134,8 +144,9 @@ Loadgen (1k TPS):
 ```
 
 ```bash
-make test   # rule unit tests
+make test   # engine, velocity, shard-assignment unit tests
 make up     # redis + dynamodb-local
+make smoke  # POST payment then poll until scored
 make down
 ```
 
@@ -200,6 +211,7 @@ cd terraform && terraform destroy
 ## Safety
 
 - Do not commit `.env`, real `*.tfvars`, access-key CSVs, or PEM keys
+- Set `ssh_ingress_cidr` in `terraform.tfvars` to your IP/32 before apply (default is open for demos)
 - Destroy idle stacks
 - Tag resources `Project=fraudguard`
 

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -61,6 +61,7 @@
             endpoint: ""
           worker_count: {{ worker_count }}
           worker_name: "{{ inventory_hostname }}"
+          worker_replicas: {{ groups['workers'] | length }}
 
     - name: systemd unit
       copy:

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -132,6 +132,30 @@ func main() {
 		})
 	})
 
+	mux.HandleFunc("POST /v1/payments/{txn_id}/dispute", func(w http.ResponseWriter, r *http.Request) {
+		txnID := r.PathValue("txn_id")
+		if txnID == "" {
+			http.Error(w, "txn_id required", http.StatusBadRequest)
+			return
+		}
+		var body struct {
+			CardID string `json:"card_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.CardID == "" {
+			http.Error(w, "card_id required", http.StatusBadRequest)
+			return
+		}
+		if err := hist.MarkDisputed(r.Context(), body.CardID, txnID); err != nil {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":  "disputed",
+			"txn_id":  txnID,
+			"card_id": body.CardID,
+		})
+	})
+
 	srv := &http.Server{Addr: cfg.HTTPAddr, Handler: mux}
 	go func() {
 		<-ctx.Done()

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -47,7 +47,7 @@ func main() {
 	})
 	must(stream.EnsureStream(ctx, client, cfg.Kinesis.StreamName, 2))
 
-	worker := stream.NewWorker(client, cfg.Kinesis.StreamName, cfg.WorkerName, cfg.WorkerCount, svc)
+	worker := stream.NewWorker(client, cfg.Kinesis.StreamName, cfg.WorkerName, cfg.WorkerCount, cfg.WorkerReplicas, svc)
 	rep := heartbeat.New(cfg.WorkerName)
 	cw := cloudwatchx.New(ctx, cfg.Kinesis.Region, cfg.WorkerName)
 
@@ -64,7 +64,9 @@ func main() {
 	})
 	go func() {
 		slog.Info("metrics listening", "addr", *metricsAddr)
-		_ = http.ListenAndServe(*metricsAddr, mux)
+		if err := http.ListenAndServe(*metricsAddr, mux); err != nil && err != http.ErrServerClosed {
+			slog.Error("metrics serve", "err", err)
+		}
 	}()
 
 	go func() {
@@ -83,7 +85,12 @@ func main() {
 		}
 	}()
 
-	slog.Info("worker running", "stream", cfg.Kinesis.StreamName, "pool", cfg.WorkerCount)
+	slog.Info("worker running",
+		"stream", cfg.Kinesis.StreamName,
+		"pool", cfg.WorkerCount,
+		"replicas", cfg.WorkerReplicas,
+		"name", cfg.WorkerName,
+	)
 	must(worker.Run(ctx))
 }
 

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -21,4 +21,5 @@ kinesis:
 
 http_addr: ":8080"
 worker_count: 32
-worker_name: "fraudguard-worker-local"
+worker_name: "fraudguard-worker-0"
+worker_replicas: 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,13 +11,14 @@ import (
 )
 
 type Config struct {
-	RedisAddr    string      `yaml:"redis_addr"`
-	Dynamo       DynamoYAML  `yaml:"dynamo"`
-	Rules        RulesYAML   `yaml:"rules"`
-	Kinesis      KinesisYAML `yaml:"kinesis"`
-	HTTPAddr     string      `yaml:"http_addr"`
-	WorkerCount  int         `yaml:"worker_count"`
-	WorkerName   string      `yaml:"worker_name"`
+	RedisAddr      string      `yaml:"redis_addr"`
+	Dynamo         DynamoYAML  `yaml:"dynamo"`
+	Rules          RulesYAML   `yaml:"rules"`
+	Kinesis        KinesisYAML `yaml:"kinesis"`
+	HTTPAddr       string      `yaml:"http_addr"`
+	WorkerCount    int         `yaml:"worker_count"`
+	WorkerName     string      `yaml:"worker_name"`
+	WorkerReplicas int         `yaml:"worker_replicas"`
 }
 
 type DynamoYAML struct {
@@ -56,7 +57,10 @@ func Load(path string) (Config, error) {
 	}
 	// back-compat if older yaml still uses consumer_name
 	if cfg.WorkerName == "" {
-		cfg.WorkerName = envOr("WORKER_NAME", "fraudguard-worker-1")
+		cfg.WorkerName = envOr("WORKER_NAME", "fraudguard-worker-0")
+	}
+	if cfg.WorkerReplicas < 1 {
+		cfg.WorkerReplicas = 1
 	}
 	return cfg, nil
 }
@@ -83,9 +87,10 @@ func Default() Config {
 			Region:     envOr("AWS_REGION", "us-east-1"),
 			Endpoint:   os.Getenv("KINESIS_ENDPOINT"),
 		},
-		HTTPAddr:    envOr("HTTP_ADDR", ":8080"),
-		WorkerCount: 32,
-		WorkerName:  envOr("WORKER_NAME", "fraudguard-worker-1"),
+		HTTPAddr:       envOr("HTTP_ADDR", ":8080"),
+		WorkerCount:    32,
+		WorkerName:     envOr("WORKER_NAME", "fraudguard-worker-0"),
+		WorkerReplicas: 1,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadWorkerReplicasDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.yaml")
+	body := []byte(`
+redis_addr: "localhost:6379"
+dynamo:
+  region: "us-east-1"
+  table_name: "t"
+  endpoint: "http://localhost:8000"
+rules:
+  amount_high_usd: 2500
+  velocity_card_limit: 5
+  velocity_card_window: "1m"
+  velocity_ip_limit: 20
+  velocity_ip_window: "1m"
+  decline_score: 80
+  review_score: 40
+kinesis:
+  stream_name: "s"
+  region: "us-east-1"
+http_addr: ":8080"
+worker_name: "fraudguard-worker-0"
+`)
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WorkerReplicas != 1 {
+		t.Fatalf("want default worker_replicas=1, got %d", cfg.WorkerReplicas)
+	}
+	eng, err := cfg.EngineConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if eng.VelocityCardWindow.String() != "1m0s" {
+		t.Fatalf("unexpected card window %v", eng.VelocityCardWindow)
+	}
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -14,6 +14,12 @@ func TestEvaluateAllow(t *testing.T) {
 	if res.Decision != payment.DecisionAllow {
 		t.Fatalf("want ALLOW, got %s score=%d", res.Decision, res.Score)
 	}
+	if res.Score != 0 {
+		t.Fatalf("want score 0, got %d", res.Score)
+	}
+	if len(res.TriggeredRules) != 0 {
+		t.Fatalf("want no rules, got %+v", res.TriggeredRules)
+	}
 }
 
 func TestEvaluateAmountAndVelocityDecline(t *testing.T) {
@@ -58,5 +64,57 @@ func TestEvaluateDeterministic(t *testing.T) {
 	b := e.Evaluate(p, snap)
 	if a.Decision != b.Decision || a.Score != b.Score || len(a.TriggeredRules) != len(b.TriggeredRules) {
 		t.Fatalf("non-deterministic: %+v vs %+v", a, b)
+	}
+}
+
+func TestEvaluateReviewThreshold(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.AmountHighUSD = 100
+	cfg.ReviewScore = 40
+	cfg.DeclineScore = 80
+	e := New(cfg)
+
+	// AMOUNT_HIGH alone = 40 → REVIEW
+	res := e.Evaluate(
+		payment.Payment{TxnID: "t5", CardID: "c", Amount: 100, IP: "1.1.1.1"},
+		Snapshot{},
+	)
+	if res.Decision != payment.DecisionReview || res.Score != 40 {
+		t.Fatalf("want REVIEW/40, got %s/%d", res.Decision, res.Score)
+	}
+}
+
+func TestEvaluateDeclineThreshold(t *testing.T) {
+	e := New(DefaultConfig())
+	// HISTORY_DISPUTE (60) + AMOUNT_HIGH (40) = 100 → DECLINE
+	res := e.Evaluate(
+		payment.Payment{TxnID: "t6", CardID: "c", Amount: 2500, IP: "1.1.1.1"},
+		Snapshot{HadDispute: true},
+	)
+	if res.Decision != payment.DecisionDecline || res.Score < 80 {
+		t.Fatalf("want DECLINE >=80, got %s/%d", res.Decision, res.Score)
+	}
+}
+
+func TestEvaluateIPVelocity(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.VelocityIPLimit = 2
+	e := New(cfg)
+	res := e.Evaluate(
+		payment.Payment{TxnID: "t7", CardID: "c", Amount: 10, IP: "9.9.9.9"},
+		Snapshot{IPVelocity: 2},
+	)
+	found := false
+	for _, r := range res.TriggeredRules {
+		if r.ID == "VELOCITY_IP" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected VELOCITY_IP")
+	}
+	if res.Decision != payment.DecisionAllow {
+		// score 30 < review 40
+		t.Fatalf("want ALLOW for IP-only, got %s score=%d", res.Decision, res.Score)
 	}
 }

--- a/internal/history/dynamodb.go
+++ b/internal/history/dynamodb.go
@@ -122,20 +122,49 @@ func (s *Store) Put(ctx context.Context, rec payment.Record) error {
 }
 
 func (s *Store) HasDispute(ctx context.Context, cardID string) (bool, error) {
-	out, err := s.client.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(s.tableName),
-		KeyConditionExpression: aws.String("card_id = :c"),
-		FilterExpression:       aws.String("disputed = :d"),
+	// DynamoDB applies Limit before FilterExpression, so Limit:1 would miss a
+	// disputed row that is not the first item for the card. Page until we find
+	// a match or exhaust the partition.
+	var startKey map[string]types.AttributeValue
+	for {
+		out, err := s.client.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String(s.tableName),
+			KeyConditionExpression: aws.String("card_id = :c"),
+			FilterExpression:       aws.String("disputed = :d"),
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":c": &types.AttributeValueMemberS{Value: cardID},
+				":d": &types.AttributeValueMemberBOOL{Value: true},
+			},
+			ExclusiveStartKey: startKey,
+		})
+		if err != nil {
+			return false, err
+		}
+		if len(out.Items) > 0 {
+			return true, nil
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			return false, nil
+		}
+		startKey = out.LastEvaluatedKey
+	}
+}
+
+// MarkDisputed sets disputed=true on an existing txn so HISTORY_DISPUTE can fire.
+func (s *Store) MarkDisputed(ctx context.Context, cardID, txnID string) error {
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"card_id": &types.AttributeValueMemberS{Value: cardID},
+			"txn_id":  &types.AttributeValueMemberS{Value: txnID},
+		},
+		UpdateExpression:    aws.String("SET disputed = :d"),
+		ConditionExpression: aws.String("attribute_exists(txn_id)"),
 		ExpressionAttributeValues: map[string]types.AttributeValue{
-			":c": &types.AttributeValueMemberS{Value: cardID},
 			":d": &types.AttributeValueMemberBOOL{Value: true},
 		},
-		Limit: aws.Int32(1),
 	})
-	if err != nil {
-		return false, err
-	}
-	return len(out.Items) > 0, nil
+	return err
 }
 
 // GetByTxnID looks up a scored payment by txn_id (via GSI).

--- a/internal/stream/assign_test.go
+++ b/internal/stream/assign_test.go
@@ -1,0 +1,54 @@
+package stream
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAssignShardsDisjoint(t *testing.T) {
+	shards := []string{"shard-2", "shard-0", "shard-1", "shard-3"}
+	a := assignShards(shards, "fraudguard-worker-0", 2)
+	b := assignShards(shards, "fraudguard-worker-1", 2)
+
+	if len(a)+len(b) != len(shards) {
+		t.Fatalf("expected full cover, got %v + %v", a, b)
+	}
+	seen := map[string]bool{}
+	for _, id := range append(append([]string{}, a...), b...) {
+		if seen[id] {
+			t.Fatalf("duplicate assignment for %s", id)
+		}
+		seen[id] = true
+	}
+	wantA := []string{"shard-0", "shard-2"}
+	wantB := []string{"shard-1", "shard-3"}
+	if !reflect.DeepEqual(a, wantA) {
+		t.Fatalf("worker-0: want %v got %v", wantA, a)
+	}
+	if !reflect.DeepEqual(b, wantB) {
+		t.Fatalf("worker-1: want %v got %v", wantB, b)
+	}
+}
+
+func TestAssignShardsSingleReplicaOwnsAll(t *testing.T) {
+	shards := []string{"b", "a"}
+	got := assignShards(shards, "fraudguard-worker-0", 1)
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want %v got %v", want, got)
+	}
+}
+
+func TestWorkerIndex(t *testing.T) {
+	cases := map[string]int{
+		"fraudguard-worker-0": 0,
+		"fraudguard-worker-3": 3,
+		"local":               0,
+		"worker":              0,
+	}
+	for name, want := range cases {
+		if got := workerIndex(name); got != want {
+			t.Fatalf("%s: want %d got %d", name, want, got)
+		}
+	}
+}

--- a/internal/stream/client.go
+++ b/internal/stream/client.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -77,23 +80,59 @@ type Worker struct {
 	streamName string
 	name       string
 	workers    int
+	replicas   int
 	scorer     *scorer.Service
 	scored     atomic.Int64
 	errors     atomic.Int64
 	latSumUs   atomic.Int64
 }
 
-func NewWorker(client *kinesis.Client, streamName, name string, workers int, s *scorer.Service) *Worker {
+func NewWorker(client *kinesis.Client, streamName, name string, workers, replicas int, s *scorer.Service) *Worker {
 	if workers < 1 {
 		workers = 8
+	}
+	if replicas < 1 {
+		replicas = 1
 	}
 	return &Worker{
 		client:     client,
 		streamName: streamName,
 		name:       name,
 		workers:    workers,
+		replicas:   replicas,
 		scorer:     s,
 	}
+}
+
+// assignShards gives each replica a disjoint subset of shards so multiple
+// EC2 workers do not double-consume the same records.
+func assignShards(shards []string, workerName string, replicas int) []string {
+	if replicas < 1 {
+		replicas = 1
+	}
+	sorted := append([]string(nil), shards...)
+	sort.Strings(sorted)
+	idx := workerIndex(workerName)
+	out := make([]string, 0, (len(sorted)/replicas)+1)
+	for i, id := range sorted {
+		if i%replicas == idx%replicas {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// workerIndex parses a trailing integer from names like "fraudguard-worker-1".
+func workerIndex(name string) int {
+	i := strings.LastIndex(name, "-")
+	if i < 0 || i+1 >= len(name) {
+		return 0
+	}
+	n, err := strconv.Atoi(name[i+1:])
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
 }
 
 func (w *Worker) Stats() (scored, errs int64, avgMs float64) {
@@ -105,11 +144,21 @@ func (w *Worker) Stats() (scored, errs int64, avgMs float64) {
 }
 
 func (w *Worker) Run(ctx context.Context) error {
-	shards, err := w.listShards(ctx)
+	allShards, err := w.listShards(ctx)
 	if err != nil {
 		return err
 	}
-	slog.Info("worker starting", "name", w.name, "shards", len(shards), "pool", w.workers)
+	shards := assignShards(allShards, w.name, w.replicas)
+	slog.Info("worker starting",
+		"name", w.name,
+		"shards_owned", len(shards),
+		"shards_total", len(allShards),
+		"replicas", w.replicas,
+		"pool", w.workers,
+	)
+	if len(shards) == 0 {
+		slog.Warn("no shards assigned to this worker; check worker_name index vs worker_replicas")
+	}
 
 	jobs := make(chan payment.Payment, w.workers*4)
 	var wg sync.WaitGroup

--- a/internal/velocity/expire_test.go
+++ b/internal/velocity/expire_test.go
@@ -1,0 +1,19 @@
+package velocity
+
+import "testing"
+
+func TestShouldExpireOnlyOnFirstIncr(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want bool
+	}{
+		{1, true},
+		{2, false},
+		{100, false},
+	}
+	for _, tc := range cases {
+		if got := shouldExpire(tc.n); got != tc.want {
+			t.Fatalf("n=%d: want %v got %v", tc.n, tc.want, got)
+		}
+	}
+}

--- a/internal/velocity/redis.go
+++ b/internal/velocity/redis.go
@@ -24,6 +24,11 @@ func New(addr string) *Store {
 	}
 }
 
+// NewWithClient builds a Store around an existing Redis client (tests).
+func NewWithClient(rdb *redis.Client) *Store {
+	return &Store{rdb: rdb}
+}
+
 func (s *Store) Ping(ctx context.Context) error { return s.rdb.Ping(ctx).Err() }
 func (s *Store) Close() error                   { return s.rdb.Close() }
 
@@ -54,12 +59,21 @@ func (s *Store) IncrIP(ctx context.Context, ip string, window time.Duration) (in
 	return s.incr(ctx, ipKey(ip), window)
 }
 
+// incr bumps the counter and sets TTL only when the key is created.
+// Refreshing EXPIRE on every hit would keep busy keys alive forever and
+// break the "N txns per window" semantics advertised by the rules.
 func (s *Store) incr(ctx context.Context, key string, window time.Duration) (int64, error) {
-	pipe := s.rdb.TxPipeline()
-	incr := pipe.Incr(ctx, key)
-	pipe.Expire(ctx, key, window)
-	if _, err := pipe.Exec(ctx); err != nil {
+	n, err := s.rdb.Incr(ctx, key).Result()
+	if err != nil {
 		return 0, err
 	}
-	return incr.Val(), nil
+	if shouldExpire(n) {
+		if err := s.rdb.Expire(ctx, key, window).Err(); err != nil {
+			return n, err
+		}
+	}
+	return n, nil
 }
+
+// shouldExpire is true when INCR just created the key (count == 1).
+func shouldExpire(n int64) bool { return n == 1 }

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+BASE="${BASE_URL:-http://localhost:8080}"
+
 echo "POST /v1/payments ..."
-curl -sf -X POST http://localhost:8080/v1/payments \
+RESP=$(curl -sf -X POST "$BASE/v1/payments" \
   -H 'Content-Type: application/json' \
   -d '{
     "card_id": "card-smoke-1",
@@ -12,6 +14,32 @@ curl -sf -X POST http://localhost:8080/v1/payments \
     "merchant": "CoffeeShop",
     "country": "US",
     "ip": "203.0.113.10"
-  }'
-echo
-echo "ok"
+  }')
+echo "$RESP"
+
+TXN_ID=$(echo "$RESP" | sed -n 's/.*"txn_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+if [[ -z "$TXN_ID" ]]; then
+  echo "failed to parse txn_id from response" >&2
+  exit 1
+fi
+
+echo "GET /v1/payments/$TXN_ID (poll until scored) ..."
+for i in $(seq 1 30); do
+  STATUS_RESP=$(curl -sf "$BASE/v1/payments/$TXN_ID")
+  STATUS=$(echo "$STATUS_RESP" | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  if [[ "$STATUS" == "scored" ]]; then
+    echo "$STATUS_RESP"
+    echo "ok"
+    exit 0
+  fi
+  # score mode returns decision inline; still pollable via DynamoDB
+  if echo "$STATUS_RESP" | grep -q '"decision"'; then
+    echo "$STATUS_RESP"
+    echo "ok"
+    exit 0
+  fi
+  sleep 0.2
+done
+
+echo "timed out waiting for score: $STATUS_RESP" >&2
+exit 1

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -83,7 +83,7 @@ resource "aws_security_group" "worker" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # TODO: lock down
+    cidr_blocks = [var.ssh_ingress_cidr]
   }
 
   ingress {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,5 +1,6 @@
-aws_region   = "us-east-1"
-project      = "fraudguard"
+aws_region    = "us-east-1"
+project       = "fraudguard"
 instance_type = "t3.small"
-worker_count = 2
-key_name     = "" # set before apply
+worker_count  = 2
+key_name      = "" # set before apply
+# ssh_ingress_cidr = "x.x.x.x/32"  # lock SSH to your IP

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,3 +23,9 @@ variable "key_name" {
   description = "EC2 key pair for SSH / Ansible"
   default     = ""
 }
+
+variable "ssh_ingress_cidr" {
+  type        = string
+  description = "CIDR allowed to SSH to bastion/workers (avoid 0.0.0.0/0 in real use)"
+  default     = "0.0.0.0/0"
+}


### PR DESCRIPTION
Prevent busy Redis keys from never expiring, make HISTORY_DISPUTE writable/queryable, partition Kinesis shards across workers, and expand unit tests plus smoke polling.